### PR TITLE
Use latest sfgui functionality to load only glyphs needed

### DIFF
--- a/SnakeFML/Main.cpp
+++ b/SnakeFML/Main.cpp
@@ -40,6 +40,10 @@ int main()
     //	Menu			menu(window,{ playButton, quitButton });
 
     sfg::SFGUI sfgui;
+
+    sfgui.AddCharacterSet(48, 58);
+    sfgui.AddCharacterSet(97, 123);
+
     sfg::Desktop desktop;
 
     auto movingCameraWidget = sfg::CheckButton::Create("Camera follows snake");


### PR DESCRIPTION
Now loading only numbers and lowercase letters (which are identical to uppercase for the font we are using).
This is a significant improvement on RAM usage (~50% decrease)

The latest SFGUI master is required.

It would be further possible to load only the exact letters used (though any future improvements to SFGUI should have a much bigger impact).